### PR TITLE
Updatedatalistnomutate

### DIFF
--- a/notes
+++ b/notes
@@ -38,5 +38,15 @@ style
     decent confidence, assuming you have comprehensive enough tests)
 - Arrange, Act, Assert as the unit test setup (pretty self-explanatory)
 
+- remember that the key property is important for react for any output dom
+  elements - it allows quickly calculation for the virtual DOM to see what
+  has changed - we don't necessarily need every single item in a react app to
+  have a unique key/id, but we do need, if these elements are mapped to a
+  collection of DOM elements/represented by them, that output list to have
+  a key for each of those elements that is unique, and this should come from
+  the underlying collection (not just the index in the array - that's bad)
+
 TODO:
 - look at the reexport setup of index.js in components/todo
+- // TODO: what is the default context in ES6? still undefined in strict mode? are we strict mode by default?
+

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ import './App.css'; // CSS modules
 // interesting that we didn't need to include index here at end of path
 // to collect - is this an ES6 feature or wrapped up in the build step?
 import {TodoForm, TodoList} from './components/todo';
-import {addTodo, generateId} from './lib/todoHelpers';
+import {addTodo, findTodoById, toggleTodoCompletion, updateTodo, generateId} from './lib/todoHelpers';
 
 class App extends Component {
   // if no constructor provided, then the default looks like this:
@@ -149,6 +149,16 @@ class App extends Component {
     });
   }
 
+  handleToggle = (id) => {
+    const todoItem = findTodoById(id, this.state.todos);
+    const toggledTodo = toggleTodoCompletion(todoItem); // new todo object returned
+    const updatedTodosList = updateTodo(this.state.todos, toggledTodo); // new list here
+
+    this.setState({
+      todos: updatedTodosList,
+    });
+  };
+
   render() {
     // note that render is called as a byproduct of whenever the setState function is 
     // called, and so what we can do is check for whether the field is empty at each
@@ -170,7 +180,7 @@ class App extends Component {
           <TodoForm currentTodo={this.state.currentTodo}
                     handleInputChange={this.handleInputChange}
                     handleSubmit={submitHandler} />
-          <TodoList todos={this.state.todos} />          
+          <TodoList todos={this.state.todos} handleToggle={this.handleToggle} />          
         </div>
       </div>
     );

--- a/src/components/todo/TodoItem.js
+++ b/src/components/todo/TodoItem.js
@@ -1,16 +1,32 @@
 import React from 'react';
+import {partial} from '../../lib/utils';
 
 // key was originally in the sibling setup here inside the actual collection;
 // now, since the key got moved, React can't just see it directly - we need
 // it back at the level of where we are looping/setting up our collection for
 // renderings
-export const TodoItem = (props) => (
+
+// we have an arrow function for toggle because we want to send back up an id;
+// we have a case where we have some event object (what the arrow function would
+// receive but we ignore) but don't want to send the event object; quite common
+// for when dealing w/ collections
+// switched defaultChecked to checked since we now have associated onChange
+// handler defined
+export const TodoItem = (props) => {
   //<li key={props.id}>
-  <li>
-    <input type="checkbox" defaultChecked={props.isComplete}/>
-    {props.name}
-  </li>
-);
+  //const handleToggle = props.handleToggle.bind(null, props.id); // this = null since not interested in resetting context
+  // TODO: what is the default context in ES6? still undefined in strict mode? are we strict mode by default?
+  
+  const handleToggle = partial(props.handleToggle, props.id);
+  return (
+    <li>
+      <input type="checkbox"
+            checked={props.isComplete}
+            onChange={handleToggle} />
+      {props.name}
+    </li>
+  );
+};
 
 // makes sense why we directly used the spread operator to pass in these
 // items from the todo object in a more flat manner (where props just clones

--- a/src/components/todo/TodoList.js
+++ b/src/components/todo/TodoList.js
@@ -13,7 +13,7 @@ import {TodoItem} from './TodoItem';
 export const TodoList = (props) => (
   <div className="Todo-List">
     <ul>
-      {props.todos.map(todo => <TodoItem key={todo.id} {...todo} />)}
+      {props.todos.map(todo => <TodoItem key={todo.id} handleToggle={props.handleToggle} {...todo} />)}
     </ul>
   </div>
 );

--- a/src/lib/todoHelpers.js
+++ b/src/lib/todoHelpers.js
@@ -12,6 +12,65 @@
   return [...todoList, newTodo];
 };*/ // just cleaning up a bit
 
+// ES6 modules top-level "this" is undefined
+
 export const addTodo = (todoList, newTodo) => [...todoList, newTodo];
+
+// using the ES6 .find method on arrays: returns the object if the predicate
+// passes (find first) or undefined if not found
+// using destructuring here for the parameters to just pull out the ID of
+// each element directly to simplify the predicate
+export const findTodoById = (idToFind, todoList) =>
+  todoList.find(({id: listItemId}) => listItemId === idToFind);
+
+// Returns a new TODO object with everything the same except the flipped 
+// isComplete boolean flag
+/*export const toggleTodoCompletion =
+  todo => Object.assign({}, todo, {
+    isComplete: !todo.isComplete
+  });*/
+
+// even handier: use the object spread operator!
+// notice here that it will first take all the values from the original todo
+// object and clone them into a new object (given by the literal {} syntax,
+// just like for arrays like above - nothing special here), and then it will
+// parse the next expression to then set the literal property isComplete to
+// some value as well
+// just like before, we are not modifying the original todo item - immutability
+export const toggleTodoCompletion =
+  todo => ({...todo, isComplete: !todo.isComplete,}); // and the parentheses to ensure parser doesn't confuse for a block
+/*
+expanded out like this:
+
+return {
+  ...todo, // spreads all enumerable own properties here into this new object created via the literal
+  isComplete: !todo.isComplete,
+}
+more here: http://www.2ality.com/2016/10/rest-spread-properties.html
+important: order matters here, since apparently objects now store keys in insertion order?
+
+*/
+
+// Returns a new todos list with the new todo in place of the original
+// Replace existing item with updated item
+export const updateTodo = (todosList, updatedTodoItem) => {
+  const updatedIndex = todosList.findIndex(({id: listItemId}) => updatedTodoItem.id === listItemId);
+  if (~updatedIndex) {
+    // notice how we are making an entirely new array here, with copied references
+    // to our existing items surrounding the insertion of a reference to this new item
+    // TODO: couldn't we also just do something like [...todosList].splice(updatedIndex, 1, updatedTodoItem),
+    // since that would copy all references to a new array and then just overwrite in this new
+    // array first?
+    return [
+      ...todosList.slice(0, updatedIndex), 
+      updatedTodoItem,
+      ...todosList.slice(updatedIndex + 1)
+    ];
+  }
+
+  // TODO: what if the index not found? (I guess we assume it is for now)
+  // could decide to throw an error or we could decide to make this more like
+  // a PUT operation and append if not already found  
+};
 
 export const generateId = () => Math.floor(Math.random() * 100000);

--- a/src/lib/todoHelpers.test.js
+++ b/src/lib/todoHelpers.test.js
@@ -1,4 +1,11 @@
-import {addTodo, generateId} from './todoHelpers';
+import {addTodo, findTodoById, toggleTodoCompletion, updateTodo, generateId} from './todoHelpers';
+
+// simple to quickly ad-hoc skip tests or test groups: just do .skip
+// conversely, can use the .only on describe or test as the complement
+// shorthand version (that does the same thing - only run this out of the
+// group of same type of blocks, so don't have to write a bunch of skips)
+
+
 
 // custom assertion
 expect.extend({
@@ -116,13 +123,190 @@ describe('addTodo function', () => {
     const result = addTodo(startTodos, newTodo);
 
     // Step 3: Assert: evaluate the results
-    expect(result).not.toBe(startTodos); // don't want the same object
+    expect(result).not.toBe(startTodos); // don't want the same object (toBe = reference equality)
   });
 });
 
+// writing this one in TDD style!
+describe('findTodoById function', () => {
+  test('findTodoById should return expected item from array', () => {
+    const startTodos = [
+      {
+        id: 1,
+        name: 'one',
+        isComplete: false,
+      },
+      {
+        id: 2,
+        name: 'two',
+        isComplete: false,
+      },
+      {
+        id: 3,
+        name: 'three',
+        isComplete: false,
+      },
+    ];
+
+    const expectedToFind = {
+      id: 2,
+      name: 'two',
+      isComplete: false,
+    };
+
+    // made this a generic variable in case want to refactor tests later - this
+    // creates an abstraction over the general "normative" use case of "finding
+    // and getting successfully some item by valid and existing ID in the list"
+    // if we just used 2 hardcoded, then (a) this test would be harder to
+    // refactor and (b) it more represents a specific test case as such: "find
+    // should return item with ID 2 from array". This is slightly pedantic but
+    // useful to think about, as we are representing the case w/ this test
+    // case of finding some ID i that should exist in our list.
+    const idToLookFor = 2;
+
+    const findResult = findTodoById(idToLookFor, startTodos);
+    expect(findResult).toEqual(expectedToFind); // note: toEqual here means recursive =, vs. toBe, which checks for identity (different from tape node module, which has equal for reference check and deepEqual for recursive check)
+  });
+});
+
+describe('toggleTodoCompletion function', () => {
+  // recall: it = test in jest
+  it('should toggle the isComplete property of a todo object', () => {
+    const startTodo = {
+      id: 1,
+      name: 'one',
+      isComplete: false,
+    };
+
+    const expectedToggledTodo = {
+      id: 1,
+      name: 'one',
+      isComplete: true,
+    };
+
+    // make sure to test both directions!
+
+    const toggledTodoResult = toggleTodoCompletion(startTodo);
+    expect(toggledTodoResult).toEqual(expectedToggledTodo);
+
+    const reverseToggleResult = toggleTodoCompletion(toggledTodoResult);
+    expect(reverseToggleResult).toEqual(startTodo);
+  });
+
+  it('should not mutate the original todo object passed in', () => {
+    const startTodo = {
+      id: 1,
+      name: 'one',
+      isComplete: false,
+    };
+
+    const toggledTodoResult = toggleTodoCompletion(startTodo);
+
+    // we have tested the preconditions above against the same object, so no
+    // need to repeat here, since making the exact same call - this is a disjoint
+    // test case against the same object/call tuple that we had from before -
+    // just splitting out for better isolation and readability
+
+    expect(toggledTodoResult).not.toBe(startTodo); // not same object reference
+  });
+
+});
+
+// updateTodo(todoList, updatedTodo)
+// this function should take in an updatedTodo and then return a new list
+// with the new item replacing a matched item in the original list
+describe('updateTodo function', () => {
+  // TODO: could add more tests here about the signature of the function and
+  // inputs, etc.
+
+  it('should update an item by id', () => {
+    const startTodos = [
+      {
+        id: 1,
+        name: 'one',
+        isComplete: false,
+      },
+      {
+        id: 2,
+        name: 'two',
+        isComplete: false,
+      },
+      {
+        id: 3,
+        name: 'three',
+        isComplete: false,
+      },
+    ];
+
+    const expectedTodos = [
+      {
+        id: 1,
+        name: 'one',
+        isComplete: false,
+      },
+      {
+        id: 2,
+        name: 'two',
+        isComplete: true,
+      },
+      {
+        id: 3,
+        name: 'three',
+        isComplete: false,
+      },
+    ];
+
+    const updatedTodoItem = {
+      id: 2,
+      name: 'two',
+      isComplete: true, // changing isComplete flag from false to true
+    };
+
+    const updatedTodosList = updateTodo(startTodos, updatedTodoItem);
+    expect(expectedTodos).toEqual(updatedTodosList); // deep recursive check of properties
+  });
+
+  // beforeEach would be very handy here...
+  it('should not update the original array', () => {
+    const startTodos = [
+      {
+        id: 1,
+        name: 'one',
+        isComplete: false,
+      },
+      {
+        id: 2,
+        name: 'two',
+        isComplete: false,
+      },
+      {
+        id: 3,
+        name: 'three',
+        isComplete: false,
+      },
+    ];
+
+    const updatedTodoItem = {
+      id: 2,
+      name: 'two',
+      isComplete: true, // changing isComplete flag from false to true
+    };
+
+    // again, this is a disjoint test over the same preconditions/invocation
+    // as before - just breaking out this test for readability (we want the
+    // assertion to be labeled under a different it/test tag line)
+    const updatedTodosList = updateTodo(startTodos, updatedTodoItem);
+    expect(updatedTodosList).not.toBe(startTodos); // don't want the same reference - don't mutate in place!
+  });
+
+  // TODO: should add tests for cases where we update with an item that doesn't
+  // already have a matching id in the array
+});
+
+
 describe('generateId function', () => {
   // test() = it()
-  test('generateId should return a number between 0 (inclusive) and 100,000 (exclusive)', () => {
+  it('should return a number between 0 (inclusive) and 100,000 (exclusive)', () => {
     const MIN_EXPECTED = 0;
     const MAX_EXPECTED = 99999;
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,9 @@
+
+
+// eh, I guess we could use this function, since we have the repeated pattern
+// of not wanting to redefine our function context (keeping null as the this value),
+// but this seems a bit overkill (and good practice of spread, rest, and binding, I guess :-D)
+export const partial = (functionToBind, ...partialApplyArgs) =>
+  functionToBind.bind(null, ...partialApplyArgs);
+
+

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -1,0 +1,18 @@
+import {partial} from './utils';
+
+const add = (a, b) => a + b;
+const addThree = (a, b, c) => a + b + c;
+
+describe('partial function', () => {
+  it('applies the first argument ahead of time', () => {
+    const inc = partial(add, 1);
+    const result = inc(2);
+    expect(result).toBe(3);
+  });
+
+  it('applies multiple arguments ahead of time', () => {
+    const inc = partial(addThree, 1, 2);
+    const result = inc(3);
+    expect(result).toBe(6);
+  });
+});


### PR DESCRIPTION
Integrated the update methods into the app officially to allow for toggling and changing the todos list, keeping the state not mutated.