### PR TITLE
Add router and start learning about component context

### DIFF
--- a/notes
+++ b/notes
@@ -49,4 +49,10 @@ style
 TODO:
 - look at the reexport setup of index.js in components/todo
 - // TODO: what is the default context in ES6? still undefined in strict mode? are we strict mode by default?
-
+- look more at the React context mechanism for components
+  - in our example, this was used to handle the case where passing down values could be a
+    maintenance nightmare through many levels (e.g. passing a callback)
+  - I wonder if multiple ancestors return a context object that they get merged? I would assume so
+  - and it seems to consume context object properly, we can just go to this.context, but also
+    just good for class API to set up the contextTypes static property (like propTypes) so we can
+    announce (and validate) what we are consuming as a descendant element

--- a/src/App.css
+++ b/src/App.css
@@ -63,3 +63,14 @@ li:hover span.delete-item {
 .error {
   color: red;
 }
+
+
+.Footer a {
+  padding-left: 2px;
+  padding-right: 2px;
+}
+
+
+.Footer a.active {
+  font-weight: bold;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -16,9 +16,10 @@ import './App.css'; // CSS modules
 // to collect - is this an ES6 feature or wrapped up in the build step?
 // RESOLVED: see the index.js file here - this is NOT an ES6 convention - it is node
 // and webpack-supported/based
-import {TodoForm, TodoList} from './components/todo';
+import {TodoForm, TodoList, Footer} from './components/todo';
 import {addTodo, findTodoById, toggleTodoCompletion, updateTodo, removeTodo, generateId} from './lib/todoHelpers';
 import {partial, compose} from './lib/utils';
+
 
 class App extends Component {
   // if no constructor provided, then the default looks like this:
@@ -200,6 +201,7 @@ class App extends Component {
           <TodoList todos={this.state.todos}
                     handleToggle={this.handleToggle}
                     handleRemove={this.handleRemove} />
+          <Footer />
         </div>
       </div>
     );

--- a/src/components/router/Link.js
+++ b/src/components/router/Link.js
@@ -1,0 +1,49 @@
+import React, {Component} from 'react';
+
+export class Link extends Component {
+  // want to consume React context in this component (available at this.context,
+  // assuming some ancestor has set up an object for this)
+  // notice the (static) property initializer syntax
+  // this not only provides a visual contract for what context we should accept
+  // but should also ensure that the ancestor passes the right thing (and that
+  // they pass it at all, assuming that they do)
+  static contextTypes = {
+    route: React.PropTypes.string,
+    linkHandler: React.PropTypes.func,
+  }; // this is all we need to do to consume context
+
+
+  handleClick = (event) => {
+    event.preventDefault(); // want to update browser's address bar and history, but not
+    // reload full page
+
+    // HTML5 History API - push router from James K Nelson tutorial
+    // TODO: should I just use a hash-based router instead and just preventDefault anyway?
+    // (stateObject, pageTitle, location to add to history)
+    // this also allows us to use back and forward buttons!
+    //history.pushState(null, '', this.props.to);
+
+    this.context.linkHandler(this.props.to);
+  }
+
+  // before, we had inserted the "to" property that gets passed in to href,
+  // but while this does update the address bar, it does a page refresh also,
+  // so need to block that manually via onClick
+  // notice that we automatically just take in the link text via the .children
+  // property, which is just whatever the component making this Link
+  // component passed in as a JSX/HTML child value
+  render() {
+    const activeClass = this.context.route === this.props.to ? 'active' : '';
+    return (
+      <a href="#" className={activeClass} onClick={this.handleClick}>{this.props.children}</a>
+    );
+  }
+}
+
+Link.propTypes = {
+  to: React.PropTypes.string.isRequired,
+};
+
+// remember: this is a class declaration here, not an expression, so you
+// don't need a semicolon - export is just a keyword/tag on top of what you
+// are already declaring! (see Exploring ES6/ES7 on 2ality)

--- a/src/components/router/Router.js
+++ b/src/components/router/Router.js
@@ -1,0 +1,76 @@
+// this component is to help handle the state of where our current location
+// is in the browser and allow other components to see it - whenever we click
+// on items in some of the links in the footer, we change where we are in
+// the browser, but we need other components to be aware of this context
+// the Footer responds to clicks to update the history/URL; if we didn't have
+// this Router component, then other components would need to do querying to
+// check where we are
+
+import React, {Component} from 'react'; // notice the default import here and then named import combined on same line
+
+const getCurrentPath = () => {
+  const path = document.location.pathname; // interesting that this property is on the document as well as window
+
+  return path.substring(path.lastIndexOf('/'));
+};
+
+export class Router extends Component {
+  // property initializer syntax (same thing as what we have when we do the
+  // fn = () => {...} vs. method declaration syntax of fn() {...}, the former
+  // of which binds to this)
+  state = {
+    route: getCurrentPath(), // set where the initial path is whenever this component gets rendered
+  } // this.state = ...
+
+  handleLinkClick = (route) => {
+    this.setState({
+      route
+    });
+    history.pushState(null, '', route); // handle update to browser history
+  };
+
+  // React context mechanism
+  // notice the (static) property initializer syntax here
+  // like propTypes but for the this.context object that descendent components
+  // can read
+  static childContextTypes = {
+    route: React.PropTypes.string,
+    linkHandler: React.PropTypes.func,
+  }
+
+  // looks like child/descendent components can access this object via this.context,
+  // where since the parent/ancestor component is set up and rendered first, this object
+  // will have been created, and then later child components during the initialization and
+  // render cycle can just view this at this.context property
+  getChildContext() {
+    return {
+      route: this.state.route,
+      linkHandler: this.handleLinkClick,
+    };
+  }
+
+  // essentially just a passthrough for just rendering whatever it wraps (in this case,
+  // it is our full application: whenever a link is clicked that updates the URL/location
+  // state of our app, we want all components to be able to access this/query the location,
+  // so we need to make the location state available as high as possible to provide to
+  // our lower components (push state up, as part of React philosophy), and so Router is
+  // higher-level than App such that all components, App and under, can access this);
+  // along the same lines, any link click that updates the URL/location will have the above
+  // handleLinkClick callback to call
+  // now, careful how you pass this down: passing down a callback like this could involve
+  // passing it down many component levels (here, we already have Router -> App -> Footer),
+  // which increases maintenance; also, since we are just passing through any generic component(s)
+  // via this.props.children, how would we pass it to them in the first place?
+  // will use the context mechanism instead
+  render() {
+    return (
+      <div>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+// again: remember that this is a class declaration, since export is just a
+// leading keyword and not a function or anything like that, so we don't need
+// the semicolon here

--- a/src/components/router/index.js
+++ b/src/components/router/index.js
@@ -1,0 +1,6 @@
+// responsibility here is to just take all components in the directory
+// and export them under the folder name itself (not standard in ES6 - this is
+// just something Node already supports, and webpack mirrors it)
+
+export {Link} from './Link';
+export {Router} from './Router';

--- a/src/components/todo/Footer.js
+++ b/src/components/todo/Footer.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import {Link} from '../router'; // shortened syntax via index.js in router directory
+
+export const Footer = (props) => (
+  <div className="Footer">
+    <Link to="/">All</Link>
+    <Link to="/active">Active</Link>
+    <Link to="/complete">Complete</Link>
+  </div>
+);

--- a/src/components/todo/index.js
+++ b/src/components/todo/index.js
@@ -9,5 +9,7 @@
 // folder
 
 // cool quick import -> re-export
+// imports and then immediately exports
 export {TodoForm} from './TodoForm';
 export {TodoList} from './TodoList';
+export {Footer} from './Footer';

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {Router} from './components/router';
 import App from './App';
 import './index.css';
 
 ReactDOM.render(
-  <App />,
+  <Router>
+    <App />
+  </Router>,
   document.getElementById('root')
 );


### PR DESCRIPTION
Learned about React component context as seemingly more centralized way to pass items to components - passing callbacks down via props through many levels of components in a tree can be very maintenance heavy, so seems like context is more of a somewhat centralized registry where the ancestor components can make some items available in a context object and then the descendant components can consume this context object. Props come down from the parent, but this is another input source for the component. Furthermore, we do this in cases where we may just have some wrapper (like for Router around App), where we don't directly create the component to even give it props, so we must do it another way.